### PR TITLE
Add a thermometer icon

### DIFF
--- a/typeface-sourcecodepro-materialdesign
+++ b/typeface-sourcecodepro-materialdesign
@@ -19,3 +19,4 @@
 #define typeface_bar_glyph_battery_unknown 
 #define typeface_bar_glyph_time 
 #define typeface_bar_glyph_workspace 
+#define typeface_bar_glyph_thermometer 


### PR DESCRIPTION
Add a thermometer icon. Discussed [here](https://github.com/regolith-linux/regolith-i3xrocks-config/pull/14#issuecomment-562406428).
I couldn't find the unicode glyph for the material [icon](https://materialdesignicons.com/icon/thermometer). I've left the one from [fontawesome](https://fontawesome.com/icons/thermometer-full?style=solid). I guess it will work with the material font, but I haven't tested it.